### PR TITLE
[setting_window] 詳細設定のダイアログボックスの実装

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,5 +39,9 @@ def login():
 def typing():
     return render_template('typing.html')
 
+@app.route('/alarm_stop')
+def alarm_stop():
+    return render_template('alarm_stop.html')
+
 if __name__ == '__main__':
     app.run(debug=True)

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -110,6 +110,7 @@ form
 .work_status,
 .detail_setting {
     text-align: center;
+    margin-bottom: 20px;
 }
 
 #work_status_button,
@@ -148,4 +149,8 @@ form
 footer {
     text-align: center;
     font-size: 10px;
+}
+
+#alarm_stop_content {
+    text-align: center;
 }

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -55,7 +55,8 @@ header {
     border-bottom: 2px solid #fff;
 }
 
-#work_status_button {
+#work_status_button,
+#show {
     color: #000;
     background-color: #fff;
     text-decoration: none;
@@ -106,11 +107,13 @@ form
     background-color: #0000;
 }
 
-.work_status{
+.work_status,
+.detail_setting {
     text-align: center;
 }
 
-#work_status_button {
+#work_status_button,
+#show {
     font-size: 16px;
     margin: 5px;
 }

--- a/static/scripts/alarm.js
+++ b/static/scripts/alarm.js
@@ -232,12 +232,11 @@ document.addEventListener('DOMContentLoaded', function() {
     // プッシュ通知
     function pushNotificaton(){
         sec++;
-        console.log(sec);
         if (workStatusButton.textContent === '退席中' || break_value === "しない"){
             noticeFlag = false;
             sec = 0;
         }
-        if(sec >= 10 && noticeFlag==true && break_value === "する"){  
+        if(sec >= 60 && noticeFlag==true && break_value === "する"){  
             sec = 0;
             Push.create('お疲れ様です！', {
                 body: '作業開始から2時間です。そろそろ休憩しましょう！',

--- a/static/scripts/alarm.js
+++ b/static/scripts/alarm.js
@@ -1,16 +1,30 @@
 document.addEventListener('DOMContentLoaded', function() {
     let timer = document.getElementById('timer')
     timer.innerHTML = "00:00";
-    let dialog = document.querySelector('dialog');
+    let typing = document.getElementById('typing');
     let workStatusButton = document.getElementById('work_status_button');
+    let setting = document.getElementById('setting');
+    let btn_show = document.getElementById('show');
+    let btn_close = document.getElementById('close');
+    let radio_break = document.getElementById("break_setting");
+    let radioBreakList = radio_break.q1;
+    let break_value = radioBreakList.value;
+    let radio_typing = document.getElementById("typing_setting");
+    let radioTypingList = radio_typing.q2;
+    let typing_value = radioTypingList.value;
+    const slider_volume = document.getElementById("volume");
+    const bgmtext = document.getElementById("btn_play");
     let timeLimit = 0;
     let timerID;
     let sec = 0;
     let startFlag = false;
     let alarmFlag = false;
     let noticeFlag = false;
+    let settingFlag = false;
     let bgm = new Audio();
     let sound = new Audio();
+    let bgm_setting = new Audio("/static/bgm/bgm-sea.mp3");
+    bgm.volume = slider_volume.value;
     let status_queue = ['active', 'active']
     resetAlarm();
     setAlarm();
@@ -29,7 +43,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const videoArea = document.getElementById('video_area');  // 映像表示エリア
         videoArea.srcObject = stream
         setInterval(function() {
-            if (workStatusButton.textContent === '作業中') {
+            if (workStatusButton.textContent === '作業中' && settingFlag === false) {
                 const canvas = document.getElementById('capture_image');  // キャンバス
                 const cct = canvas.getContext('2d');  // キャンバスの画像表示エリア
                 canvas.width  = videoArea.videoWidth;
@@ -93,7 +107,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }, false);
 
-    dialog.addEventListener('close', function() {
+    typing.addEventListener('close', function() {
         alarmFlag = false;
         stop();
     }, false);
@@ -150,11 +164,9 @@ document.addEventListener('DOMContentLoaded', function() {
         } 
         noticeFlag = false;  
         sec = 0; 
-        console.log('start')
     }
     
     function stop() {
-        console.log('stop');
         clearInterval(timerID);
         bgm.pause();
         sound.pause();
@@ -177,25 +189,26 @@ document.addEventListener('DOMContentLoaded', function() {
             bgm.pause();
             sound.play();
             timer.innerHTML = "Wake Up!";
-            dialog.showModal();
-            init();
-            typingGame();
+            if (typing_value === "する") {
+                typing.showModal();
+                init();
+                typingGame();
+            }    
             noticeFlag = true;
             sec = 0;
-            console.log('time');
         }
     }
 
+    // プッシュ通知
     function pushNotificaton(){
         sec++;
         console.log(sec);
-        if (workStatusButton.textContent === '退席中'){
+        if (workStatusButton.textContent === '退席中' || break_value === "しない"){
             noticeFlag = false;
             sec = 0;
         }
-        if(sec >= 60 && noticeFlag==true){  
+        if(sec >= 10 && noticeFlag==true && break_value === "する"){  
             sec = 0;
-            console.log('push')
             flag = false;
             Push.create('お疲れ様です！', {
                 body: '作業開始から2時間です。そろそろ休憩しましょう！',
@@ -207,4 +220,36 @@ document.addEventListener('DOMContentLoaded', function() {
         }    
     }
     setInterval(pushNotificaton, 1000);
+
+    // 詳細設定
+    btn_show.addEventListener('click', function() {
+        setting.showModal();
+        stop();
+        settingFlag = true;
+    }, false);
+    btn_close.addEventListener('click', function() {
+        bgm_setting.pause();
+        bgmtext.textContent = "再生";
+        break_value = radioBreakList.value;
+        typing_value = radioTypingList.value;
+        settingFlag = false;
+        setting.close();
+    }, false);
+    
+    btn_play.addEventListener("click", e => {
+        if (bgmtext.textContent === "再生"){
+            bgm_setting.play();
+            bgmtext.textContent = "一時停止";
+        }
+        else {
+            bgm_setting.pause();
+            bgmtext.textContent = "再生";
+        }
+    })
+    
+    slider_volume.addEventListener("input", e => {
+        bgm_setting.volume = slider_volume.value;
+        bgm.volume = slider_volume.value;
+    });
+
 }, false);

--- a/static/scripts/alarm.js
+++ b/static/scripts/alarm.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', function() {
     let typing = document.getElementById('typing');
     let workStatusButton = document.getElementById('work_status_button');
     let setting = document.getElementById('setting');
+    let alarmStopDialog = document.getElementById('alarm_stop_dialog');
     let btn_show = document.getElementById('show');
     let btn_close = document.getElementById('close');
     let radio_break = document.getElementById("break_setting");
@@ -98,9 +99,11 @@ document.addEventListener('DOMContentLoaded', function() {
     workStatusButton.addEventListener("click", function() {
         if (workStatusButton.textContent === '作業中') {
             workStatusButton.textContent = '退席中';
+            clearInterval(timerID);
+            bgm.pause();
+            startFlag = false;
             noticeFlag = false; 
-
-            stop();
+            resetAlarm();
         } else {
             workStatusButton.textContent = '作業中';
             noticeFlag = true;
@@ -110,6 +113,12 @@ document.addEventListener('DOMContentLoaded', function() {
     typing.addEventListener('close', function() {
         alarmFlag = false;
         stop();
+    }, false);
+
+    document.getElementById('alarm_stop_button').addEventListener('click', function() {
+        alarmFlag = false;
+        stop();
+        alarmStopDialog.close();
     }, false);
 
 
@@ -193,7 +202,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 typing.showModal();
                 init();
                 typingGame();
-            }    
+            } else {
+                alarmStopDialog.showModal();
+            }
             noticeFlag = true;
             sec = 0;
         }
@@ -209,7 +220,6 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         if(sec >= 10 && noticeFlag==true && break_value === "する"){  
             sec = 0;
-            flag = false;
             Push.create('お疲れ様です！', {
                 body: '作業開始から2時間です。そろそろ休憩しましょう！',
                 timeout: 5000,
@@ -224,7 +234,9 @@ document.addEventListener('DOMContentLoaded', function() {
     // 詳細設定
     btn_show.addEventListener('click', function() {
         setting.showModal();
-        stop();
+        clearInterval(timerID);
+        resetAlarm();
+        bgm.pause();
         settingFlag = true;
     }, false);
     btn_close.addEventListener('click', function() {
@@ -234,6 +246,7 @@ document.addEventListener('DOMContentLoaded', function() {
         typing_value = radioTypingList.value;
         settingFlag = false;
         setting.close();
+        startFlag = false;
     }, false);
     
     btn_play.addEventListener("click", e => {

--- a/static/scripts/alarm.js
+++ b/static/scripts/alarm.js
@@ -3,7 +3,6 @@ document.addEventListener('DOMContentLoaded', function() {
     timer.innerHTML = "00:00";
     let workStatusButton = document.getElementById('work_status_button');
     let setting = document.getElementById('setting');
-    let alarmStopDialog = document.getElementById('alarm_stop_dialog');
     let btn_show = document.getElementById('show');
     let btn_close = document.getElementById('close');
     let radio_break = document.getElementById("break_setting");
@@ -117,23 +116,20 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }, false);
 
-    document.getElementById('alarm_stop_button').addEventListener('click', function() {
-        alarmFlag = false;
-        stop();
-        alarmStopDialog.close();
-    }, false);
-
     // 1秒ごとにクッキーでアラームとタイピングゲームの状態を判断
     let typing = setInterval(function() {
-        if (typing_value === 'する') {
-            if (document.cookie === 'typing=1') {
-                if (subWindow.closed) {
+        if (document.cookie === 'typing=1') {
+            if (subWindow.closed) {
+                if (typing_value === 'する') {
                     subWindow = window.open('/typing', null, getPosition());
+                } else {
+                    alarmFlag = false;
+                    stop();
                 }
-            } else if (document.cookie === 'typing=2') {
-                alarmFlag = false;
-                stop();
             }
+        } else if (document.cookie === 'typing=2') {
+            alarmFlag = false;
+            stop();
         }
     }, 1000);
 
@@ -220,7 +216,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (typing_value === "する") {
                 subWindow = window.open('/typing', null, getPosition());
             } else {
-                alarmStopDialog.showModal();
+                subWindow = window.open('/alarm_stop', null, getPosition());
             }
             noticeFlag = true;
             sec = 0;

--- a/static/scripts/alarm.js
+++ b/static/scripts/alarm.js
@@ -43,7 +43,8 @@ document.addEventListener('DOMContentLoaded', function() {
         const videoArea = document.getElementById('video_area');  // 映像表示エリア
         videoArea.srcObject = stream
         setInterval(function() {
-            if (workStatusButton.textContent === '作業中' && settingFlag === false) {
+            if (workStatusButton.textContent === '作業中' && settingFlag == false) {
+                console.log("aa")
                 const canvas = document.getElementById('capture_image');  // キャンバス
                 const cct = canvas.getContext('2d');  // キャンバスの画像表示エリア
                 canvas.width  = videoArea.videoWidth;
@@ -99,7 +100,6 @@ document.addEventListener('DOMContentLoaded', function() {
         if (workStatusButton.textContent === '作業中') {
             workStatusButton.textContent = '退席中';
             noticeFlag = false; 
-
             stop();
         } else {
             workStatusButton.textContent = '作業中';
@@ -175,6 +175,14 @@ document.addEventListener('DOMContentLoaded', function() {
         resetAlarm();
     }
 
+    function stopTyping() {
+        clearInterval(timerID);
+        bgm.pause();
+        noticeFlag = true;
+        startFlag = false;
+        resetAlarm();
+    }
+
     // 時間表示、bgm、アラームを鳴らす関数
     function time() {
         let minute = ("00" + Math.floor((timeLimit / 1000) / 60)).slice(-2);
@@ -224,7 +232,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // 詳細設定
     btn_show.addEventListener('click', function() {
         setting.showModal();
-        stop();
+        stopTyping();
         settingFlag = true;
     }, false);
     btn_close.addEventListener('click', function() {

--- a/static/scripts/alarm_stop.js
+++ b/static/scripts/alarm_stop.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', function() {
+    if (!window.opener || window.opener.closed) {
+        window.alert('親ウインドウがありません。');
+        return false;
+    }
+    
+    document.getElementById('alarm_stop_button').addEventListener('click', function() {
+        document.cookie = 'typing=2'
+        window.close();
+    }, false);
+}, false);

--- a/static/scripts/typing.js
+++ b/static/scripts/typing.js
@@ -1,4 +1,4 @@
-const dialog = document.querySelector('dialog');
+const typing = document.getElementById('typing');
 const array_j = ['さあ張り切って頑張りましょう。', 'ハングリーであれ、愚かであれ。', 'ソースコードは嘘をつかない', '枯れないバグは無い', '美はシンプルさに宿る'];
 const array_a = ['saaharikitteganbarimashou.','hanguri-deare,orokadeare.','so-suko-dohausowotukanai','karenaibaguhanai','bihasinpurusaniyadoru']
 let used_j = [];
@@ -53,7 +53,7 @@ function show_keydown(phrase_a){
                 const newArray_a = await array_a.filter(i => used_a.indexOf(i) === -1);
                 if (newArray_j.length === 2) {
                     alphabet_s = "";
-                    dialog.close();
+                    typing.close();
                 }
                 await typingGame(newArray_j,newArray_a);
             }

--- a/templates/alarm_stop.html
+++ b/templates/alarm_stop.html
@@ -13,7 +13,7 @@
             <h2 class="title"><a href="/typing">Reboot sleeper</a></a></h2>
         </div>
     </header>
-    <div class="entire">
+    <div id="alarm_stop_content" class="entire">
         <h1>おはようございます！</h1>
         <button id="alarm_stop_button"><h2>アラームストップ</h2></button>
     </div>

--- a/templates/alarm_stop.html
+++ b/templates/alarm_stop.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Reboot sleeper</title>
+    <link rel="stylesheet" type="text/css" href="/static/css/index.css">
+</head>
+<body>
+    <header>
+        <div class="header_content">
+            <h2 class="title"><a href="/typing">Reboot sleeper</a></a></h2>
+        </div>
+    </header>
+    <div class="entire">
+        <h1>おはようございます！</h1>
+        <button id="alarm_stop_button"><h2>アラームストップ</h2></button>
+    </div>
+    <script src="/static/scripts/alarm_stop.js"></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -59,14 +59,44 @@
             </div>
         </form>
 
+        <div class="detail_setting">
+            <button id="show" class="show">詳細設定</button>
+        </div>
+
         <div class='work_status'>
             <span>作業状態</span>
             <button id="work_status_button">作業中</button>
         </div>
+
+        <footer>
+            <p id="license">この作品のアラーム音は「OtoLogic」の音源を<a href="https://creativecommons.org/licenses/by/4.0/legalcode.ja">CC BY 4.0</a>のライセンスのもとで使用しています。</p>
+        </footer>
     </div>
     
+    <dialog id="setting">
+        <p>詳細設定</p>
+        <p>休憩通知<br>
+            <form id="break_setting">
+                <input type="radio" name="q1" value="する" checked> する
+                <input type="radio" name="q1" value="しない"> しない
+            </form>
+        </p>
+        <p>起床後のタイピングゲーム<br>
+            <form id="typing_setting">
+                <input type="radio" name="q2" value="する" checked> する
+                <input type="radio" name="q2" value="しない"> しない
+            </form>
+        </p>
+        <p>bgmの音量<br>
+            <input type="range" id="volume" value="0.5" min="0.0" max="1.0" step="0.1">
+            <button id="btn_play">再生</button>
+        </p>
+        
+        <button id="close">決定</button>
+    </dialog>
+
     <!-- タイピングゲーム -->
-    <dialog>
+    <dialog id="typing">
         <p id="count"></p>
         <p id="japanese"></p>
         <p id="alphabet"></p>
@@ -75,10 +105,6 @@
     <!-- CSSで非表示に設定してある -->
     <video id="video_area" autoplay></video>
     <canvas id="capture_image"></canvas>
-
-    <footer>
-        <p id="license">この作品のアラーム音は「OtoLogic」の音源を<a href="https://creativecommons.org/licenses/by/4.0/legalcode.ja">CC BY 4.0</a>のライセンスのもとで使用しています。</p>
-    </footer>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script type='text/javascript' src="/static/scripts/clock.js"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -95,10 +95,6 @@
         <button id="close">決定</button>
     </dialog>
 
-    <dialog id="alarm_stop_dialog">
-        <button id="alarm_stop_button">アラームストップ</button>
-    </dialog>
-
     <!-- CSSで非表示に設定してある -->
     <video id="video_area" autoplay></video>
     <canvas id="capture_image"></canvas>

--- a/templates/index.html
+++ b/templates/index.html
@@ -95,6 +95,10 @@
         <button id="close">決定</button>
     </dialog>
 
+    <dialog id="alarm_stop_dialog">
+        <button id="alarm_stop_button">アラームストップ</button>
+    </dialog>
+
     <!-- タイピングゲーム -->
     <dialog id="typing">
         <p id="count"></p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -74,7 +74,7 @@
     </div>
     
     <dialog id="setting">
-        <p>詳細設定</p>
+        <h3>詳細設定</h3>
         <p>休憩通知<br>
             <form id="break_setting">
                 <input type="radio" name="q1" value="する" checked> する


### PR DESCRIPTION
**概要**
詳細設定のダイアログウィンドウを実装した。
設定できる内容は、プッシュ通知とタイピングゲーム機能のon/offの設定、bgmの音量設定ができる。
現段階では、タイピングゲームをオフにした場合アラームを止めるにはページを更新するしかない。（どうしよう...）
詳細設定のダイアログを開いているときはタイマーがリセットされる。（退席中の時と同じ状態）
閉じるとタイマーを動かせる。（作業中の時と同じ状態）

**受け入れ条件**
ダイアログウィンドウが現れる。
設定した内容が反映される。
その他不具合が起きない。