### PR TITLE
Popup typing　タイピングゲームを別ウインドウで出す

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,5 +35,9 @@ def activity_log():
 def login():
     return render_template('login.html')
 
+@app.route('/typing')
+def typing():
+    return render_template('typing.html')
+
 if __name__ == '__main__':
     app.run(debug=True)

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -21,7 +21,7 @@ body{
 
 header {
     background-color: #000;
-    padding: 10px 0 15px;
+    padding: 20px 0 20px;
 }
 
 .header_content {
@@ -128,9 +128,18 @@ form
     display: none;
 }
 
-dialog #japanese {
-    font-weight: bolder;
-    margin: 0px;
+#typing_area {
+    margin: 50px;
+}
+
+#count,
+#japanese,
+#alphabet {
+    font-size: 20px;
+}
+
+#japanese {
+    margin-top: 40px;
 }
 
 footer {

--- a/static/scripts/alarm.js
+++ b/static/scripts/alarm.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', function() {
     let timerID;
     let startFlag = false;
     let alarmFlag = false;
+    let $bgmChoice;
     let bgm = new Audio();
     let sound = new Audio();
     let status_queue = ['active', 'active']
@@ -88,7 +89,9 @@ document.addEventListener('DOMContentLoaded', function() {
     workStatusButton.addEventListener("click", function() {
         if (workStatusButton.textContent === '作業中') {
             workStatusButton.textContent = '退席中';
-            stop();
+            resetAlarm();
+            startFlag = false;
+            clearInterval(timerID);
         } else {
             workStatusButton.textContent = '作業中';
         }
@@ -140,7 +143,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function setBGM() {
-        let $bgmChoice = document.getElementById("bgm").value;
+        $bgmChoice = document.getElementById("bgm").value;
         bgm.pause();
         if ($bgmChoice === 'none') {
             bgm = new Audio();
@@ -151,7 +154,9 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     
     function start() {
-        bgm.play();
+        if ($bgmChoice != 'none') {
+            bgm.play();
+        }
         if ((! startFlag) && (timeLimit > 0)){
             startFlag = true;
             timerID = setInterval(time, 1000)
@@ -159,7 +164,6 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     
     function stop() {
-        clearInterval(timerID);
         bgm.pause();
         sound.pause();
         startFlag = false;

--- a/static/scripts/alarm.js
+++ b/static/scripts/alarm.js
@@ -89,10 +89,11 @@ document.addEventListener('DOMContentLoaded', function() {
     workStatusButton.addEventListener("click", function() {
         if (workStatusButton.textContent === '作業中') {
             workStatusButton.textContent = '退席中';
-            resetAlarm();
-            startFlag = false;
             clearInterval(timerID);
+            bgm.pause();
+            startFlag = false;
             noticeFlag = false; 
+            resetAlarm();
         } else {
             workStatusButton.textContent = '作業中';
             noticeFlag = true;
@@ -169,7 +170,6 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     
     function stop() {
-        console.log('stop');
         clearInterval(timerID);
         bgm.pause();
         sound.pause();

--- a/static/scripts/alarm.js
+++ b/static/scripts/alarm.js
@@ -13,10 +13,8 @@ document.addEventListener('DOMContentLoaded', function() {
     let sound = new Audio();
     let status_queue = ['active', 'active']
     let subWindow;  // サブウインドウのオブジェクト
-    var WIDTH = 800;
+    const WIDTH = 800;
     const HEIGHT = 500;
-    const X = window.screenX + (window.outerWidth / 2) - (WIDTH / 2);
-    const Y = window.screenY + (window.outerHeight / 2) - (HEIGHT / 2);
     resetAlarm();
     setAlarm();
     setBGM();
@@ -105,7 +103,7 @@ document.addEventListener('DOMContentLoaded', function() {
     let typing = setInterval(function() {
         if (document.cookie === 'typing=1') {
             if (subWindow.closed) {
-                subWindow = window.open('/typing', null, 'left='+X+',top='+Y+',width='+WIDTH+',height='+HEIGHT);
+                subWindow = window.open('/typing', null, getPosition());
             }
         } else if (document.cookie === 'typing=2') {
             document.cookie = 'typing=0';
@@ -195,11 +193,17 @@ document.addEventListener('DOMContentLoaded', function() {
             sound.play();
             timer.innerHTML = "Wake Up!";
             document.cookie = 'typing=1'
-            subWindow = window.open('/typing', null, 'left='+X+',top='+Y+',width='+WIDTH+',height='+HEIGHT);
+            subWindow = window.open('/typing', null, getPosition());
             noticeFlag = true;
             sec = 0;
             console.log('time');
         }
+    }
+
+    function getPosition(width=WIDTH, height=HEIGHT) {
+        const x = window.screenX + (window.outerWidth / 2) - (width / 2);
+        const y = window.screenY + (window.outerHeight / 2) - (height / 2);
+        return 'left='+x+',top='+y+',width='+width+',height='+height;
     }
 
     function pushNotificaton(){

--- a/static/scripts/alarm.js
+++ b/static/scripts/alarm.js
@@ -1,7 +1,6 @@
 document.addEventListener('DOMContentLoaded', function() {
     let timer = document.getElementById('timer')
     timer.innerHTML = "00:00";
-    let dialog = document.querySelector('dialog');
     let workStatusButton = document.getElementById('work_status_button');
     let timeLimit = 0;
     let timerID;
@@ -10,9 +9,16 @@ document.addEventListener('DOMContentLoaded', function() {
     let bgm = new Audio();
     let sound = new Audio();
     let status_queue = ['active', 'active']
+    let subWindow;  // サブウインドウのオブジェクト
+    var WIDTH = 800;
+    const HEIGHT = 500;
+    const X = window.screenX + (window.outerWidth / 2) - (WIDTH / 2);
+    const Y = window.screenY + (window.outerHeight / 2) - (HEIGHT / 2);
     resetAlarm();
     setAlarm();
     setBGM();
+    // 0:1と2以外、1:アラームが鳴っている、2:タイピングによりサブウインドウが閉じられたとき
+    document.cookie = 'typing=0';
 
 
     // getUserMedia が使えないブラウザのとき
@@ -88,11 +94,18 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }, false);
 
-    dialog.addEventListener('close', function() {
-        alarmFlag = false;
-        stop();
-    }, false);
-
+    // 1秒ごとにクッキーでアラームとタイピングゲームの状態を判断
+    let typing = setInterval(function() {
+        if (document.cookie === 'typing=1') {
+            if (subWindow.closed) {
+                subWindow = window.open('/typing', null, 'left='+X+',top='+Y+',width='+WIDTH+',height='+HEIGHT);
+            }
+        } else if (document.cookie === 'typing=2') {
+            document.cookie = 'typing=0';
+            alarmFlag = false;
+            stop();
+        }
+    }, 1000);
 
     function resetAlarm() {
         let $alarmTime = document.getElementById("alarmTime").value;
@@ -167,9 +180,8 @@ document.addEventListener('DOMContentLoaded', function() {
             bgm.pause();
             sound.play();
             timer.innerHTML = "Wake Up!";
-            dialog.showModal();
-            init();
-            typingGame();
+            document.cookie = 'typing=1'
+            subWindow = window.open('/typing', null, 'left='+X+',top='+Y+',width='+WIDTH+',height='+HEIGHT);
         }
     }
 }, false);

--- a/static/scripts/typing.js
+++ b/static/scripts/typing.js
@@ -1,62 +1,75 @@
-const dialog = document.querySelector('dialog');
-const array_j = ['さあ張り切って頑張りましょう。', 'ハングリーであれ、愚かであれ。', 'ソースコードは嘘をつかない', '枯れないバグは無い', '美はシンプルさに宿る'];
-const array_a = ['saaharikitteganbarimashou.','hanguri-deare,orokadeare.','so-suko-dohausowotukanai','karenaibaguhanai','bihasinpurusaniyadoru']
-let used_j = [];
-let used_a = [];
-let idx = 0;
-
-function init(){
-    shuffle();
-    used_a = [];
-    used_j = [];
-    idx = 0;
-}
-
-function typingGame(use_j = array_j, use_a = array_a){
-    phrase_j = use_j[0];
-    phrase_a = use_a[0];
-    l = use_j.length;
-    printSentence(phrase_j,phrase_a,l);
-    show_keydown(phrase_a);
-}
-
-function shuffle(){
-    for(var i = array_j.length - 1; i > 0; i--) {
-        var j = Math.floor(Math.random() * (i + 1));
-        var tmp = array_j[i];
-        array_j[i] = array_j[j];
-        array_j[j] = tmp;
-
-        tmp = array_a[i];
-        array_a[i] = array_a[j];
-        array_a[j] = tmp;
+document.addEventListener('DOMContentLoaded', function () {
+    if (!window.opener || window.opener.closed) {
+        window.alert('親ウインドウがありません。');
+        return false;
     }
-}
+    
+    const count = document.getElementById('count');
+    const japanese = document.getElementById('japanese');
+    const alphabet = document.getElementById('alphabet');
+    const array_j = ['さあ張り切って頑張りましょう。', 'ハングリーであれ、愚かであれ。', 'ソースコードは嘘をつかない', '枯れないバグは無い', '美はシンプルさに宿る'];
+    const array_a = ['saaharikitteganbarimashou.','hanguri-deare,orokadeare.','so-suko-dohausowotukanai','karenaibaguhanai','bihasinpurusaniyadoru']
+    let used_j = [];
+    let used_a = [];
+    let idx = 0;
 
-function printSentence(phrase_j,phrase_a,l){
-    count.innerHTML = '下の文章を入力してください　　'+(6-l)+'/3';
-    japanese.innerHTML = phrase_j;
-    alphabet.innerHTML = phrase_a;
-}
+    init();
+    typingGame();
 
-function show_keydown(phrase_a){
-    document.onkeydown = async function(e){
-        let key = e.key;
-        if(key === phrase_a[idx]){
-            idx += 1;
-            alphabet.innerHTML = phrase_a.slice(idx,);
-            if (idx === phrase_a.length) {
-                idx = 0;
-                await used_j.push(japanese.innerHTML);
-                const newArray_j = await array_j.filter(i => used_j.indexOf(i) === -1);
-                await used_a.push(phrase_a);
-                const newArray_a = await array_a.filter(i => used_a.indexOf(i) === -1);
-                if (newArray_j.length === 2) {
-                    alphabet_s = "";
-                    dialog.close();
-                }
-                await typingGame(newArray_j,newArray_a);
-            }
+    function init(){
+        shuffle();
+        used_a = [];
+        used_j = [];
+        idx = 0;
+    }
+
+    function typingGame(use_j = array_j, use_a = array_a){
+        phrase_j = use_j[0];
+        phrase_a = use_a[0];
+        l = use_j.length;
+        printSentence(phrase_j,phrase_a,l);
+        show_keydown(phrase_a);
+    }
+
+    function shuffle(){
+        for(var i = array_j.length - 1; i > 0; i--) {
+            var j = Math.floor(Math.random() * (i + 1));
+            var tmp = array_j[i];
+            array_j[i] = array_j[j];
+            array_j[j] = tmp;
+
+            tmp = array_a[i];
+            array_a[i] = array_a[j];
+            array_a[j] = tmp;
         }
     }
-}
+
+    function printSentence(phrase_j,phrase_a,l){
+        count.innerHTML = '下の文章を入力してください　　'+(6-l)+'/3';
+        japanese.innerHTML = phrase_j;
+        alphabet.innerHTML = phrase_a;
+    }
+
+    function show_keydown(phrase_a){
+        document.onkeydown = async function(e){
+            let key = e.key;
+            if(key === phrase_a[idx]){
+                idx += 1;
+                alphabet.innerHTML = phrase_a.slice(idx,);
+                if (idx === phrase_a.length) {
+                    idx = 0;
+                    await used_j.push(japanese.innerHTML);
+                    const newArray_j = await array_j.filter(i => used_j.indexOf(i) === -1);
+                    await used_a.push(phrase_a);
+                    const newArray_a = await array_a.filter(i => used_a.indexOf(i) === -1);
+                    if (newArray_j.length === 2) {
+                        alphabet_s = "";
+                        document.cookie = 'typing=2';
+                        window.close();
+                    }
+                    await typingGame(newArray_j,newArray_a);
+                }
+            }
+        }
+    }  
+}, false);

--- a/templates/activity_log.html
+++ b/templates/activity_log.html
@@ -4,7 +4,7 @@
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>(仮)Health Care for Engineer</title>
+    <title>Reboot sleeper</title>
     <link rel="stylesheet" type="text/css" href="/static/css/index.css">
 </head>
 <body>

--- a/templates/detection_test.html
+++ b/templates/detection_test.html
@@ -4,7 +4,7 @@
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>(仮)Health Care for Engineer</title>
+    <title>Reboot sleeper</title>
     <link rel="stylesheet" type="text/css" href="/static/css/index.css">
 </head>
 <body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -63,13 +63,6 @@
             <button id="work_status_button">作業中</button>
         </div>
     </div>
-    
-    <!-- タイピングゲーム -->
-    <dialog>
-        <p id="count"></p>
-        <p id="japanese"></p>
-        <p id="alphabet"></p>
-    </dialog>
 
     <!-- CSSで非表示に設定してある -->
     <video id="video_area" autoplay></video>
@@ -82,6 +75,5 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script type='text/javascript' src="/static/scripts/clock.js"></script>
     <script type='text/javascript' src="/static/scripts/alarm.js"></script>
-    <script type='text/javascript' src="/static/scripts/typing.js"></script>
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -4,7 +4,7 @@
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>(仮)Health Care for Engineer</title>
+    <title>Reboot sleeper</title>
     <link rel="stylesheet" type="text/css" href="/static/css/index.css">
 </head>
 <body>

--- a/templates/typing.html
+++ b/templates/typing.html
@@ -8,9 +8,11 @@
     <link rel="stylesheet" type="text/css" href="/static/css/index.css">
 </head>
 <body>
-    <div class="entire">
-        タイピングゲーム
+    <div id="typing_area" class="entire">
+        <p id="count"></p>
+        <p id="japanese"></p>
+        <p id="alphabet"></p>
     </div>
-    <script src="/static/scripts/subwindow.js"></script>
+    <script src="/static/scripts/typing.js"></script>
 </body>
 </html>

--- a/templates/typing.html
+++ b/templates/typing.html
@@ -8,6 +8,11 @@
     <link rel="stylesheet" type="text/css" href="/static/css/index.css">
 </head>
 <body>
+    <header>
+        <div class="header_content">
+            <h2 class="title"><a href="/typing">Reboot sleeper</a></a></h2>
+        </div>
+    </header>
     <div id="typing_area" class="entire">
         <p id="count"></p>
         <p id="japanese"></p>

--- a/templates/typing.html
+++ b/templates/typing.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Reboot sleeper</title>
+    <link rel="stylesheet" type="text/css" href="/static/css/index.css">
+</head>
+<body>
+    <div class="entire">
+        タイピングゲーム
+    </div>
+    <script src="/static/scripts/subwindow.js"></script>
+</body>
+</html>


### PR DESCRIPTION
# 概要
#31 を実装
アプリ本体を親ウインドウ，タイピングゲームを子ウインドウとする．

- カウントがゼロになると，アラームが鳴り，子ウインドウにタイピングゲームが出てくる
- 子ウインドウのタイピングゲームを終了すると，子ウインドウが自動的に閉じ，一瞬遅れてアラームも停止（一瞬遅れるのは仕様）．初めに戻る．
- 子ウインドウの右上の×を押すと，子ウインドウが復活
- その他，JSのバグの修正とHTML，CSSの微調整
- 今回のコミットでクッキーを使う必要が出てきてしまったので，クッキーの許可設定とか気を付けて

# 受け入れ条件

- アラームおよびタイピングゲームで致命的な不具合がないこと
- タイピングゲームを無事に終了した場合のみアラームが停止すること
- （ちなみに親ウインドウをリロードしてもアラームが止まるのは仕様です...）